### PR TITLE
Add support for optionally copying only changed files (while watching)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ plugins:{
   copycat:{
     "fonts" : ["bower_components/material-design-iconic-font", "bower_components/font-awesome/fonts"],
     "images": ["someDirectoryInProject", "bower_components/some_package/assets/images"],
-    verbose : true //shows each file that is copied to the destination directory
+    verbose : true, //shows each file that is copied to the destination directory
+    onlyChanged: true //only copy a file if it's mtime has changed (only effective when using watch)
   }
 }
 ```

--- a/lib/cat.js
+++ b/lib/cat.js
@@ -3,11 +3,17 @@ var mkdirp = require('mkdirp'),
   path = require('path'),
   fs = require('fs'),
   logger = require('loggy');
+
+var mtimes = {};
+
 var cat = (function(){
-  var _0777 = parseInt('0777', 8), copiedFiles = [], verbose = false;
+  var _0777 = parseInt('0777', 8), copiedFiles = [], verbose = false, onlyChanged = false, notModifiedCount = 0;
   return {
     setVerbose: function(v) {
       verbose = v;
+    },
+    setOnlyChanged: function(c) {
+      onlyChanged = c;
     },
     mkdir: function(target){
       var _return = true;
@@ -17,26 +23,45 @@ var cat = (function(){
       return _return;
     },
     copyFolderRecursiveAsync: function(source, target){
+      notModifiedCount = 0;
+
       if (!fs.existsSync(target))
         this.mkdir(target);
 
-      if (fs.lstatSync(source).isDirectory()){
+      var stat = fs.lstatSync(source);
+
+      if (stat.isDirectory()){
         files = fs.readdirSync(source);
         files.forEach(function (file) {
           var curSource = path.join(source, file);
-          if (fs.lstatSync(curSource).isDirectory()){
+
+          stat = fs.lstatSync(curSource);
+
+          if (stat.isDirectory()){
             var curTarget = path.join(target, path.basename(curSource));
             cat.copyFolderRecursiveAsync(curSource, curTarget);
           }else{
-            cat.copyFileAsync(curSource, target);
+            cat.copyFileAsync(curSource, target, stat);
           }
         });
       }else{
-        this.copyFileAsync(source, target);
+        this.copyFileAsync(source, target, stat);
       }
-	  logger.info('[copycat] copied ' + copiedFiles.length + ' files');
+
+      var notModifiedMsg = onlyChanged ? ' (' + notModifiedCount + ' files were not modified)' : '';
+
+	  logger.info('[copycat] copied ' + copiedFiles.length + ' files' + notModifiedMsg);
     },
-    copyFileAsync: function(original, copy){
+    copyFileAsync: function(original, copy, stat){
+      if (onlyChanged) {
+        if ((mtimes[original] || 0) >= stat.mtime.getTime()) {
+          notModifiedCount += 1;
+          return;
+        }
+
+        mtimes[original] = stat.mtime.getTime();
+      }
+
       _copyFile = path.join(copy, path.basename(original));
       copiedFiles.push(_copyFile);
       copyFile(original, _copyFile, function(error) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,9 @@ copycat.prototype.extension='js';
 
 copycat.prototype.onCompile = function(data, path, callback) {
   var verbose = 'verbose';
+  var onlyChanged = 'onlyChanged';
   cat.setVerbose(params.plugins.copycat[verbose] ? params.plugins.copycat[verbose] : false);
+  cat.setOnlyChanged(params.plugins.copycat[onlyChanged] ? params.plugins.copycat[onlyChanged] : false);
   Object.keys(params.plugins.copycat).forEach(function(key){
     var destination = key;
     var directories = params.plugins.copycat[key];


### PR DESCRIPTION
This commit adds the option `onlyChanged` which, when true, causes copycat to save the files mtime and only copy a file if it's mtime is newer than the one stored (this only works while the `node` / `brunch` process keeps running, thus will only be effective when using `brunch watch`). 
