### PR TITLE
Bumped loggy dependency version to address crit vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "test": "node_modules/.bin/mocha"
   },
   "dependencies": {
+    "loggy": "^1.0.4",
     "mkdirp": "^0.5.1",
-    "quickly-copy-file": "^0.1.0",
-    "loggy": "~0.2.2"
+    "quickly-copy-file": "^0.1.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
The version of loggy in use is dependent on a growl package with critical vulnerability. 

![image](https://user-images.githubusercontent.com/107891/45848071-c3547600-bcf2-11e8-9863-4138dd75d66f.png)

This PR bumps loggy dependency version.